### PR TITLE
refactor: modernize codebase with Go 1.26 features

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,6 +19,7 @@ linters:
     - gosec
     - makezero
     - misspell
+    - modernize
     - nakedret
     - nestif
     - nolintlint

--- a/go.mod
+++ b/go.mod
@@ -207,7 +207,7 @@ require (
 	go.augendre.info/fatcontext v0.9.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
+	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/internal/framer_test.go
+++ b/internal/framer_test.go
@@ -212,7 +212,7 @@ func BenchmarkChunkedReadByte(b *testing.B) {
 	for _, bc := range readers {
 		b.Run(bc.name, func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_, _ = bc.r.ReadByte()
 				b.SetBytes(1)
 			}
@@ -236,7 +236,7 @@ func BenchmarkChunkedRead(b *testing.B) {
 	for _, bc := range readers {
 		b.Run(bc.name, func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				src.Reset(rfcChunkedRPC)
 				dstBuf.Reset()
 				n, err := io.Copy(&dst, bc.r)
@@ -390,7 +390,7 @@ func BenchmarkEOMReadByte(b *testing.B) {
 	for _, bc := range readers {
 		b.Run(bc.name, func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_, _ = bc.r.ReadByte()
 				b.SetBytes(1)
 			}
@@ -415,7 +415,7 @@ func BenchmarkEOMRead(b *testing.B) {
 	for _, bc := range readers {
 		b.Run(bc.name, func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				src.Reset(rfcEOMRPC)
 				dstBuf.Reset()
 				n, err := io.Copy(&dst, bc.r)

--- a/msg.go
+++ b/msg.go
@@ -1,12 +1,12 @@
 package netconf
 
 import (
+	"cmp"
 	"encoding/xml"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
-
-	"golang.org/x/exp/slices"
 )
 
 type RawXML []byte
@@ -160,11 +160,7 @@ type RPCError struct {
 }
 
 func (e RPCError) Error() string {
-	if e.Message != "" {
-		return e.Message
-	} else {
-		return string(e.Info)
-	}
+	return cmp.Or(e.Message, string(e.Info))
 }
 
 type RPCErrors []RPCError

--- a/operations.go
+++ b/operations.go
@@ -238,7 +238,7 @@ func NewEditConfigRequest(target Datastore, config any, opts ...EditConfigOption
 	case []byte:
 		v = bytes.TrimSpace(v)
 		if !bytes.HasSuffix(v, []byte(configSuffix)) {
-			v = []byte(fmt.Sprintf("%s\n%s\n%s", configPrefix+">", v, configSuffix))
+			v = fmt.Appendf(nil, "%s\n%s\n%s", configPrefix+">", v, configSuffix)
 		}
 		req.Inner = v
 	case URL:

--- a/transport/ssh/ssh_test.go
+++ b/transport/ssh/ssh_test.go
@@ -2,7 +2,6 @@ package ssh
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"log"
@@ -121,7 +120,7 @@ func TestTransport(t *testing.T) {
 		//nolint:gosec
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
-	tr, err := Dial(context.Background(), "tcp", server.addr.String(), config, WithDebugCapture(os.Stdout, os.Stdout))
+	tr, err := Dial(t.Context(), "tcp", server.addr.String(), config, WithDebugCapture(os.Stdout, os.Stdout))
 	require.NoError(t, err)
 
 	// test read


### PR DESCRIPTION
- Replace `x/exp/slices` with stdlib `slices`
- Use `cmp.Or` for first-non-zero pattern
- Use `fmt.Appendf` instead of `[]byte(fmt.Sprintf(...))`
- Use `t.Context()` instead of `context.Background()` in tests
- Use `range` over int in benchmarks
- Enable `modernize` linter in golangci-lint