### PR TITLE
fix: add XML declaration and vendor namespace support

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -34,9 +34,10 @@ func (x *RawXML) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 }
 
 type RPC struct {
-	XMLName   xml.Name `xml:"urn:ietf:params:xml:ns:netconf:base:1.0 rpc"`
-	MessageID uint64   `xml:"message-id,attr"`
-	Operation any      `xml:",innerxml"`
+	XMLName   xml.Name   `xml:"urn:ietf:params:xml:ns:netconf:base:1.0 rpc"`
+	MessageID uint64     `xml:"message-id,attr"`
+	Attrs     []xml.Attr `xml:"-"`
+	Operation any        `xml:",innerxml"`
 }
 
 func (msg *RPC) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
@@ -46,7 +47,20 @@ func (msg *RPC) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
 
 	type rpcMsg RPC
 	inner := rpcMsg(*msg)
-	return e.Encode(&inner)
+
+	if len(msg.Attrs) == 0 {
+		return e.Encode(&inner)
+	}
+
+	start := xml.StartElement{
+		Name: xml.Name{Space: baseNetconfNs, Local: "rpc"},
+		Attr: append([]xml.Attr{
+			{Name: xml.Name{Local: "message-id"}, Value: fmt.Sprintf("%d", msg.MessageID)},
+		}, msg.Attrs...),
+	}
+	return e.EncodeElement(&struct {
+		Operation any `xml:",innerxml"`
+	}{Operation: inner.Operation}, start)
 }
 
 type Hello struct {

--- a/operations_test.go
+++ b/operations_test.go
@@ -214,7 +214,7 @@ func TestDiscardChanges(t *testing.T) {
 	}{
 		{
 			name:  "discard-changes",
-			match: `<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1"><discard-changes xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"></discard-changes></rpc>`,
+			match: xml.Header + `<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1"><discard-changes xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"></discard-changes></rpc>`,
 		},
 	}
 

--- a/session.go
+++ b/session.go
@@ -105,6 +105,19 @@ func WithErrorSeverity(severity ...ErrSeverity) SessionOption {
 	}}
 }
 
+// WithRPCAttr adds an extra XML attribute to every outgoing <rpc> element.
+// This is typically used to declare vendor-specific namespace prefixes, e.g.:
+//
+//	WithRPCAttr("xmlns:nxos", "http://www.cisco.com/nxos:1.0")
+func WithRPCAttr(name, value string) SessionOption {
+	return sessionOpt{func(sess *Session) {
+		sess.rpcAttrs = append(sess.rpcAttrs, xml.Attr{
+			Name:  xml.Name{Local: name},
+			Value: value,
+		})
+	}}
+}
+
 // WithHelloTimeout sets the timeout for hello messages. Default is 30 seconds.
 func WithHelloTimeout(timeout time.Duration) SessionOption {
 	return sessionOpt{func(sess *Session) {
@@ -125,6 +138,7 @@ type Session struct {
 
 	notificationHandler NotificationHandler
 	errSeverity         []ErrSeverity
+	rpcAttrs            []xml.Attr
 
 	mu           sync.Mutex
 	helloTimeout time.Duration
@@ -404,6 +418,7 @@ func (s *Session) call(ctx context.Context, req any, resp any) error {
 func (s *Session) do(ctx context.Context, req any) (*RPCReply, error) {
 	msg := &RPC{
 		MessageID: s.seq.Add(1),
+		Attrs:     s.rpcAttrs,
 		Operation: req,
 	}
 
@@ -442,12 +457,17 @@ func (s *Session) send(msg *RPC) (chan RPCReply, error) {
 	return ch, nil
 }
 
+var xmlHeader = []byte(xml.Header)
+
 func (s *Session) writeMsg(v any) error {
 	w, err := s.tr.MsgWriter()
 	if err != nil {
 		return err
 	}
 
+	if _, err := w.Write(xmlHeader); err != nil {
+		return err
+	}
 	if err := xml.NewEncoder(w).Encode(v); err != nil {
 		return err
 	}

--- a/vendor.go
+++ b/vendor.go
@@ -1,0 +1,16 @@
+package netconf
+
+// CiscoNXOSAttrs provides the namespace attributes required by Cisco NX-OS
+// legacy NX-API XML NETCONF stack (port 22, "feature nxapi").
+var CiscoNXOSAttrs = []SessionOption{
+	WithRPCAttr("xmlns:nxos", "http://www.cisco.com/nxos:1.0"),
+	WithRPCAttr("xmlns:if", "http://www.cisco.com/nxos:1.0:if_manager"),
+	WithRPCAttr("xmlns:nfcli", "http://www.cisco.com/nxos:1.0:nfcli"),
+	WithRPCAttr("xmlns:vlan_mgr_cli", "http://www.cisco.com/nxos:1.0:vlan_mgr_cli"),
+}
+
+// HPComwareAttrs provides the namespace attributes used by HP Comware devices.
+var HPComwareAttrs = []SessionOption{
+	WithRPCAttr("xmlns:data", "http://www.hp.com/netconf/data:1.0"),
+	WithRPCAttr("xmlns:config", "http://www.hp.com/netconf/config:1.0"),
+}


### PR DESCRIPTION
Go `xml.Encoder` does not emit XML declarations, which causes legacy Cisco NX-OS (NX-API XML stack) to reject RPCs with "Wrong document: namespaces not specified".

## Changes

- Add `<?xml version="1.0" encoding="UTF-8"?>` header to every outgoing NETCONF message
- Add `WithRPCAttr(name, value)` session option for declaring extra xmlns attributes on `<rpc>` elements
- Add well-known vendor presets in `vendor.go`:
  - `CiscoNXOSAttrs` — required namespace prefixes for NX-OS legacy NX-API XML stack
  - `HPComwareAttrs` — namespace prefixes for HP Comware devices

## Usage

```go
opts := []netconf.SessionOption{
    netconf.WithTransport(transport),
}
opts = append(opts, netconf.CiscoNXOSAttrs...)
session, err := netconf.NewSession(ctx, opts...)
```

Tested against Cisco Nexus NX-OS 10.2(4) via legacy NX-API XML NETCONF (port 22).