### PR TITLE
fix: stop Get hanging on vendor XML with illegal control chars

### DIFF
--- a/get_operations_test.go
+++ b/get_operations_test.go
@@ -1,8 +1,10 @@
 package netconf
 
 import (
+	"context"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -137,4 +139,49 @@ func TestGet(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetWithIllegalControlCharacter(t *testing.T) {
+	ts := newTestServer(t)
+	sess, err := newSession(WithTransport(ts.transport()))
+	require.NoError(t, err)
+	sess.serverCaps = newCapabilitySet(DefaultCapabilities...)
+	go sess.recv()
+
+	replyXML := "<rpc-reply xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"1\">" +
+		"<data><If-list><id>eth1/47</id><adj-items><AdjEp-list>" +
+		"<id>1</id><capability>bridge,router</capability>" +
+		"<chassisIdT>7</chassisIdT><chassisIdV>aa-\nbb-cc\x02</chassisIdV>" +
+		"</AdjEp-list></adj-items></If-list></data></rpc-reply>"
+	ts.queueResp([]byte(replyXML))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	reply, err := sess.Get(ctx, WithSubtreeFilter(`<state/>`))
+	require.NoError(t, err)
+	require.NotNil(t, reply)
+	require.Equal(t, uint64(1), reply.MessageID)
+	require.Contains(t, string(reply.Raw()), "<chassisIdV>aa-\nbb-cc</chassisIdV>")
+	require.NotContains(t, string(reply.Raw()), "\x02")
+}
+
+func TestGetDeliversReplyWhenDecodeFails(t *testing.T) {
+	ts := newTestServer(t)
+	sess, err := newSession(WithTransport(ts.transport()))
+	require.NoError(t, err)
+	sess.serverCaps = newCapabilitySet(DefaultCapabilities...)
+	go sess.recv()
+
+	// Unescaped ]]> is illegal XML 1.0 and is not stripped by sanitizeXML.
+	ts.queueRespString(`<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1"><data>foo]]>bar</data></rpc-reply>`)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	reply, err := sess.Get(ctx, WithSubtreeFilter(`<state/>`))
+	require.NoError(t, err)
+	require.NotNil(t, reply)
+	require.Equal(t, uint64(1), reply.MessageID)
+	require.Contains(t, string(reply.Raw()), "foo]]>bar")
 }

--- a/session.go
+++ b/session.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -33,6 +34,67 @@ func charsetReader(label string, input io.Reader) (io.Reader, error) {
 		return input, nil
 	}
 	return enc.NewDecoder().Reader(input), nil
+}
+
+func isIllegalXMLByte(b []byte, i int) int {
+	c := b[i]
+	switch {
+	case c < 0x20 && c != '\t' && c != '\n' && c != '\r':
+		return 1
+	case c == 0xEF && i+2 < len(b) && b[i+1] == 0xBF && (b[i+2] == 0xBE || b[i+2] == 0xBF):
+		return 3
+	default:
+		return 0
+	}
+}
+
+func sanitizeXML(b []byte) []byte {
+	for i := 0; i < len(b); {
+		n := isIllegalXMLByte(b, i)
+		if n == 0 {
+			i++
+			continue
+		}
+		out := make([]byte, i, len(b)-n)
+		copy(out, b[:i])
+		for i += n; i < len(b); {
+			n = isIllegalXMLByte(b, i)
+			if n == 0 {
+				out = append(out, b[i])
+				i++
+				continue
+			}
+			i += n
+		}
+		return out
+	}
+	return b
+}
+
+func messageIDFromRaw(raw []byte) uint64 {
+	const prefix = "message-id="
+	i := bytes.Index(raw, []byte(prefix))
+	if i < 0 {
+		return 0
+	}
+	i += len(prefix)
+	if i >= len(raw) {
+		return 0
+	}
+	quote := raw[i]
+	if quote != '"' && quote != '\'' {
+		return 0
+	}
+	i++
+	end := bytes.IndexByte(raw[i:], quote)
+	if end < 0 {
+		return 0
+	}
+	id, err := strconv.ParseUint(string(raw[i:i+end]), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return id
 }
 
 // ISession is definition of the operations that this netconf client provides.
@@ -295,6 +357,7 @@ func (s *Session) recvMsg() error {
 	if err != nil {
 		return err
 	}
+	raw = sanitizeXML(raw)
 
 	var elem *xml.StartElement
 	dec := xml.NewDecoder(bytes.NewReader(raw))
@@ -315,7 +378,10 @@ func (s *Session) recvMsg() error {
 	case "rpc-reply":
 		rpcReply := RPCReply{rpc: raw}
 		if err := dec.DecodeElement(&rpcReply, elem); err != nil {
-			return fmt.Errorf("failed to decode rpc-reply message: %w", err)
+			s.logger.Errorf("failed to decode rpc-reply message: %v", err)
+			if rpcReply.MessageID == 0 {
+				rpcReply.MessageID = messageIDFromRaw(raw)
+			}
 		}
 
 		ok, req := s.req(rpcReply.MessageID)

--- a/session_test.go
+++ b/session_test.go
@@ -92,6 +92,44 @@ func (s *testTransport) Close() error {
 	return nil
 }
 
+func TestSanitizeXML(t *testing.T) {
+	tt := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "clean", in: "<a>ok</a>", want: "<a>ok</a>"},
+		{name: "stx", in: "<a>aa-\nbb-cc\x02</a>", want: "<a>aa-\nbb-cc</a>"},
+		{name: "nul", in: "<a>\x00x</a>", want: "<a>x</a>"},
+		{name: "tab newline cr kept", in: "<a>\t\n\r</a>", want: "<a>\t\n\r</a>"},
+		{name: "utf8 nonchar", in: "<a>\xEF\xBF\xBE</a>", want: "<a></a>"},
+		{name: "empty", in: "", want: ""},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, []byte(tc.want), sanitizeXML([]byte(tc.in)))
+		})
+	}
+}
+
+func TestMessageIDFromRaw(t *testing.T) {
+	tt := []struct {
+		name string
+		in   string
+		want uint64
+	}{
+		{name: "double quote", in: `<rpc-reply message-id="42">`, want: 42},
+		{name: "single quote", in: `<rpc-reply message-id='7'>`, want: 7},
+		{name: "missing", in: `<rpc-reply>`, want: 0},
+		{name: "unquoted", in: `<rpc-reply message-id=3>`, want: 0},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, messageIDFromRaw([]byte(tc.in)))
+		})
+	}
+}
+
 func TestNonUTF8HelloMessage(t *testing.T) {
 	ts := newTestServer(t)
 	sess, err := newSession(WithTransport(ts.transport()))


### PR DESCRIPTION
## Summary

Vendors sometimes put XML 1.0-illegal control characters in NETCONF replies (Nokia LLDP `chassisIdV` with a raw STX/`\x02` is the trigger we hit). `encoding/xml` then fails in `recvMsg` while decoding `<rpc-reply>`.

That error never reaches `Get`. `recv` only logs it and waits for the next message. The reply channel is never written or closed, so `Get`/`GetConfig` hang until the session dies or the caller context times out.

- Strip XML 1.0-illegal bytes (C0 controls except TAB/LF/CR, U+FFFE/U+FFFF) before decode. Clean replies are not copied.
- If decode still fails, log and deliver the raw reply using `message-id` from the start tag so the caller is not stuck.
- Tests cover the STX chassis-id case and a remaining illegal `]]>` payload.

## Test plan

- [x] `go test -race -count=1 .`
- [x] `golangci-lint run ./...`